### PR TITLE
added support for phone, with option to provide its custom regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .pub/
 build/
 doc/api/
+.vscode/

--- a/example/linkify_example.dart
+++ b/example/linkify_example.dart
@@ -1,6 +1,10 @@
 import 'package:linkify/linkify.dart';
 
 void main() {
-  print(linkify("Made by https://cretezy.com person@example.com"));
-  // Output: [TextElement: 'Made by ', LinkElement: 'https://cretezy.com' (https://cretezy.com), TextElement: ' ', EmailElement: 'person@example.com' (person@example.com)]
+  print(linkify(
+    "Made by https://cretezy.com person@example.com +1 (92345) 23452",
+  ));
+  // Output: [TextElement: 'Made by ', LinkElement: 'https://cretezy.com' (https://cretezy.com),
+  // TextElement: ' ', EmailElement: 'person@example.com' (person@example.com),
+  // TextElement: ' ', PhoneElement: '+1 (92345) 23452' (+1 (92345) 23452)]
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,7 +37,7 @@ packages:
     source: hosted
     version: "1.1.2"
   collection:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: collection
       url: "https://pub.dartlang.org"


### PR DESCRIPTION
I have added support for phone numbers like
+91 99999 99999
+1 123 123 123
+41 (555) 555 555
9999999999 , etc
Regex is: ^((?:.|\n)*?)((tel:)?([+0-9]{2,4}?\s?[0-9\s\(\)]{8,15})) 

I have also added a way for user to provide a **custom regex**,
in the **linkify method** using phoneRegex - which is an optional named parameter, so **no breaking change** is introduced