### PR TITLE
fix regex doesn't found matches when carriage return(\r) included

### DIFF
--- a/lib/linkify.dart
+++ b/lib/linkify.dart
@@ -92,6 +92,7 @@ List<LinkifyElement> linkify(
   List<LinkType> linkTypes,
 }) {
   final list = List<LinkifyElement>();
+  text = text.replaceAll("\r", "");
 
   if (text == null || text.isEmpty) {
     return list;


### PR DESCRIPTION
if string contains ```\r```, then regex cannot find matches.

I tried to edit regex to make matching job to work, I couldn't.

so I added code that remove all ```\r``` characters.

I think RegExp() class of dart has bug.

```dotAll: true``` options also doesn't work.

below is test strings. try test.


```
text = "test_link1: \nhttps://github.com/\ntest_link2 : \nhttps://github.com/"
```
**=> working**


```
text = "test_link1: \r\nhttps://github.com/\r\ntest_link2 : \r\nhttps://github.com/"
```
**=> not working**
