### PR TITLE
Option to enable or disable printing of output. Defaults to false

### DIFF
--- a/lib/linkify.dart
+++ b/lib/linkify.dart
@@ -54,8 +54,9 @@ abstract class Linkifier {
 class LinkifyOptions {
   /// Removes http/https from shown URLS.
   final bool humanize;
+  final bool printOutput;
 
-  LinkifyOptions({this.humanize = true});
+  LinkifyOptions({this.humanize = true, this.printOutput = false});
 }
 
 const _urlLinkifier = UrlLinkifier();
@@ -86,10 +87,12 @@ List<LinkifyElement> linkify(
 
   options ??= LinkifyOptions();
 
-  linkifiers.forEach((linkifier) {
-    list = linkifier.parse(list, options);
-    print(list);
-  });
+    linkifiers.forEach((linkifier){
+      list = linkifier.parse(list, options);
+      if(options.printOutput == true){
+        print(list);
+      }
+    });
 
   return list;
 }


### PR DESCRIPTION
I think the the printing of the linkify methods output just clutters up everything when you don't want to see it. It is also confusing when you're using the flutter_linkify package, as you might not even be aware of where the print is coming from. However, since it might be a good way to debug, I still left it in as an option.