### PR TITLE
match CR (\r) in addition to LF (\n) 

### DIFF
--- a/lib/src/email.dart
+++ b/lib/src/email.dart
@@ -1,8 +1,9 @@
 import 'package:linkify/linkify.dart';
 
 final _emailRegex = RegExp(
-  r'^((?:.|\n)*?)((mailto:)?[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})',
+  r'^(.*?)((mailto:)?[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})',
   caseSensitive: false,
+  dotAll: true,
 );
 
 class EmailLinkifier extends Linkifier {

--- a/lib/src/url.dart
+++ b/lib/src/url.dart
@@ -1,13 +1,15 @@
 import 'package:linkify/linkify.dart';
 
 final _urlRegex = RegExp(
-  r'^((?:.|\n)*?)((?:https?):\/\/[^\s/$.?#].[^\s]*)',
+  r'^(.*?)((?:https?):\/\/[^\s/$.?#].[^\s]*)',
   caseSensitive: false,
+  dotAll: true,
 );
 
 final _looseUrlRegex = RegExp(
-  r'^((?:.|\n)*?)([^\s]*\.[^\s]*)',
+  r'^(.*?)([^\s]*\.[^\s]*)',
   caseSensitive: false,
+  dotAll: true,
 );
 
 class UrlLinkifier extends Linkifier {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Charles Crete <charles@cretezy.com>
 homepage: https://github.com/Cretezy/linkify
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.4.0 <3.0.0"
 
 dev_dependencies:
   collection: ^1.0.0

--- a/test/linkify_test.dart
+++ b/test/linkify_test.dart
@@ -171,4 +171,14 @@ void main() {
       ],
     );
   });
+
+  test('Parses CR correctly.', () {
+    expectListEqual(
+      linkify('lorem\r\nipsum https://example.com'),
+      [
+        TextElement('lorem\r\nipsum '),
+        UrlElement('https://example.com', 'example.com'),
+      ],
+    );
+  });
 }


### PR DESCRIPTION
Fixes #20 and #15 and #22 .. and is similar to #9 - but instead of just getting rid of CR's will simply make the regex to mach all \r as well as \n. Makes the regex a bit easier to read imo.

but requires dart 2.4.