### PR TITLE
Make email matcher more permissive on TLD

### DIFF
--- a/lib/src/email.dart
+++ b/lib/src/email.dart
@@ -1,7 +1,7 @@
 import 'package:linkify/linkify.dart';
 
 final _emailRegex = RegExp(
-  r'^(.*?)((mailto:)?[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})',
+  r'^(.*?)((mailto:)?[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z][A-Z]+)',
   caseSensitive: false,
   dotAll: true,
 );


### PR DESCRIPTION
In our case `.health` was not matched at all