### PR TITLE
Fix loose URL not being parsed if the text have a non loose URL

### DIFF
--- a/lib/src/url.dart
+++ b/lib/src/url.dart
@@ -26,13 +26,9 @@ class UrlLinkifier extends Linkifier {
 
     elements.forEach((element) {
       if (element is TextElement) {
-        var loose = false;
-        var match = _urlRegex.firstMatch(element.text);
-
-        if (match == null && options.looseUrl) {
-          match = _looseUrlRegex.firstMatch(element.text);
-          loose = true;
-        }
+        var match = options.looseUrl
+            ? _looseUrlRegex.firstMatch(element.text)
+            : _urlRegex.firstMatch(element.text);
 
         if (match == null) {
           list.add(element);
@@ -55,7 +51,7 @@ class UrlLinkifier extends Linkifier {
 
             var url = originalUrl;
 
-            if (loose || !originalUrl.startsWith(_protocolIdentifierRegex)) {
+            if (!originalUrl.startsWith(_protocolIdentifierRegex)) {
               originalUrl = (options.defaultToHttps ? "https://" : "http://") +
                   originalUrl;
             }

--- a/test/linkify_test.dart
+++ b/test/linkify_test.dart
@@ -167,6 +167,32 @@ void main() {
     );
   });
 
+  test('Parses both loose and not URL on the same text', () {
+    expectListEqual(
+      linkify('example.com http://example.com',
+          options: LinkifyOptions(looseUrl: true)),
+      [
+        UrlElement('http://example.com', 'example.com'),
+        TextElement(' '),
+        UrlElement('http://example.com', 'example.com')
+      ],
+    );
+
+    expectListEqual(
+      linkify(
+          'This text mixes both loose urls like example.com and not loose urls like http://example.com and http://another.example.com',
+          options: LinkifyOptions(looseUrl: true)),
+      [
+        TextElement('This text mixes both loose urls like '),
+        UrlElement('http://example.com', 'example.com'),
+        TextElement(' and not loose urls like '),
+        UrlElement('http://example.com', 'example.com'),
+        TextElement(' and '),
+        UrlElement('http://another.example.com', 'another.example.com')
+      ],
+    );
+  });
+
   test('Parses ending period', () {
     expectListEqual(
       linkify("https://example.com/test."),


### PR DESCRIPTION
This PR fixes #40 where a text with both loose and not loose URLs was not being properly parsed.

I've added 2 tests that reproduce the issue and then fixed it.

The main issue is that even if the `looseUrl` option is set to `true`, the first match is using the full `_urlRegex`, so if the text contains both a loose and a not loose URL the first part of the text is parsed as `TextElement` even it has a loose URL.

