### PR TITLE
✨ Add Origin Text

### DIFF
--- a/lib/linkify.dart
+++ b/lib/linkify.dart
@@ -9,8 +9,11 @@ export 'package:linkify/src/user_tag.dart'
 
 abstract class LinkifyElement {
   final String text;
+  final String originText;
 
-  LinkifyElement(this.text);
+  LinkifyElement(text, [String? originText]) :
+      this.text = text,
+      this.originText = originText ?? text;
 
   @override
   bool operator ==(other) => equals(other);
@@ -21,7 +24,7 @@ abstract class LinkifyElement {
 class LinkableElement extends LinkifyElement {
   final String url;
 
-  LinkableElement(String? text, this.url) : super(text ?? url);
+  LinkableElement(String? text, this.url, [String? originText]) : super(text ?? url, originText);
 
   @override
   bool operator ==(other) => equals(other);

--- a/lib/src/url.dart
+++ b/lib/src/url.dart
@@ -41,11 +41,13 @@ class UrlLinkifier extends Linkifier {
 
           if (match.group(2)?.isNotEmpty == true) {
             var originalUrl = match.group(2)!;
+            var originText = originalUrl;
             String? end;
 
             if ((options.excludeLastPeriod) &&
                 originalUrl[originalUrl.length - 1] == ".") {
               end = ".";
+              originText = originText.substring(0, originText.length - 1);
               originalUrl = originalUrl.substring(0, originalUrl.length - 1);
             }
 
@@ -67,9 +69,10 @@ class UrlLinkifier extends Linkifier {
               list.add(UrlElement(
                 originalUrl,
                 url,
+                originText,
               ));
             } else {
-              list.add(UrlElement(originalUrl));
+              list.add(UrlElement(originalUrl, null, originText));
             }
 
             if (end != null) {
@@ -92,7 +95,7 @@ class UrlLinkifier extends Linkifier {
 
 /// Represents an element containing a link
 class UrlElement extends LinkableElement {
-  UrlElement(String url, [String? text]) : super(text, url);
+  UrlElement(String url, [String? text, String? originText]) : super(text, url, originText);
 
   @override
   String toString() {


### PR DESCRIPTION
### Current State

Currently there is not a way to capture the original text that contributed to a `LinkifyElement`. Instead, only the modified text is available.

### Desired State

A `LinkifyElement` has the property `originText` where the original text is captured.

### Why

An example of this is when parsing text containing a URL i.e.

```
ssuper.co is one way to specify a website, https://ssuper.co is another way
```

If using `humanize=False`, we get this when we recreate the phrase from the parsed elements

```
https://ssuper.co is one way to specify a website, https://ssuper.co is another way
```

Or, if using `humanize=True`, we get this

```
ssuper.co is one way to specify a website, ssuper.co is another way
```

This is an issue when using Linkify to parse text for a `TextEditingController`. **Because the original text is not recoverable from LinkifyElement, there is no way to reliably mirror the original text the user types.** Having an `originText` property fixes this.

**Current Workaround**: https://stackoverflow.com/a/65914757 