### PR TITLE
Add quotation marks to loose url regex

### DIFF
--- a/lib/src/url.dart
+++ b/lib/src/url.dart
@@ -7,7 +7,7 @@ final _urlRegex = RegExp(
 );
 
 final _looseUrlRegex = RegExp(
-  r'^(.*?)((https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))',
+  r'^(.*?)((https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//="'`]*))',
   caseSensitive: false,
   dotAll: true,
 );


### PR DESCRIPTION
Adds quotation characters to loose url regex for cases such as example.com/over/there?name="ferret" 
Related to #49 