### PR TITLE
Fix email are parsed as Url when looseUrl option is true.

### DIFF
--- a/lib/linkify.dart
+++ b/lib/linkify.dart
@@ -94,7 +94,7 @@ class LinkifyOptions {
 
 const _urlLinkifier = UrlLinkifier();
 const _emailLinkifier = EmailLinkifier();
-const defaultLinkifiers = [_urlLinkifier, _emailLinkifier];
+const defaultLinkifiers = [_emailLinkifier, _urlLinkifier];
 
 /// Turns [text] into a list of [LinkifyElement]
 ///


### PR DESCRIPTION
- swap defaultLinkifiers order between url and email to prevent email parse as url when looseUrl option is true